### PR TITLE
fix: ensure sign atlas textures are correctly registered

### DIFF
--- a/frame-woods-v0/src/main/java/net/moddingplayground/frame/api/woods/v0/FrameSignType.java
+++ b/frame-woods-v0/src/main/java/net/moddingplayground/frame/api/woods/v0/FrameSignType.java
@@ -1,5 +1,9 @@
 package net.moddingplayground.frame.api.woods.v0;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.util.SpriteIdentifier;
+import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.SignType;
 import net.moddingplayground.frame.api.rendering.v0.SignTextureProvider;
@@ -42,6 +46,16 @@ public class FrameSignType extends SignType implements SignTextureProvider {
      *          want to use
      */
     public static FrameSignType register(Identifier id) {
-        return (FrameSignType) register(new FrameSignType(id));
+        FrameSignType sign = (FrameSignType) register(new FrameSignType(id));
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+            Identifier texture = new Identifier(id.getNamespace(), "entity/signs/%s".formatted(id.getPath()));
+            TexturedRenderLayers.WOOD_TYPE_TEXTURES.put(
+                sign, new SpriteIdentifier(
+                    TexturedRenderLayers.SIGNS_ATLAS_TEXTURE, texture
+                )
+            );
+        };
+
+        return sign;
     }
 }


### PR DESCRIPTION
ensure sign atlas textures are registered to avoid a crash later on (with Expanded Storage)